### PR TITLE
release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,3 @@ jobs:
           publish: ./scripts/release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     branches:
-      - dev
+      - main 
 
 permissions:
   contents: write

--- a/scripts/release
+++ b/scripts/release
@@ -4,4 +4,23 @@ set -e
 
 (cd packages/frontend && bun run build)
 (cd packages/opencontrol && bun run build)
-bun changeset publish
+
+tar -cvf opencontrol.tar.gz -C packages opencontrol
+
+VERSION=$(node -p "require('./packages/opencontrol/package.json').version")
+
+# Extract changelog notes for the current version
+CHANGELOG_FILE="packages/opencontrol/CHANGELOG.md"
+NOTES=$(awk -v version="## $VERSION" '
+  BEGIN { print_notes = 0 }
+  $0 ~ version { print_notes = 1; next }
+  print_notes && /^## / { exit }
+  print_notes && !/^\s*$/ { print }
+' "$CHANGELOG_FILE" | sed 's/^/    /')
+
+# If no notes found, use a fallback message
+if [ -z "$NOTES" ]; then
+  NOTES="Automated patch bump for push to master"
+fi
+
+gh release create "v$VERSION" opencontrol.tar.gz --title "v$VERSION" --notes "$NOTES"

--- a/scripts/release
+++ b/scripts/release
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 
+# Get version from package.json
+VERSION=$(node -p "require('./packages/opencontrol/package.json').version")
+
+# Check if release already exists
+if gh release view "v$VERSION" &>/dev/null; then
+  echo "Error: Release v$VERSION already exists. Please call bun changeset version."
+  exit 0
+fi
+
 set -e
 
 (cd packages/frontend && bun run build)
 (cd packages/opencontrol && bun run build)
 
 tar -cvf opencontrol.tar.gz -C packages opencontrol
-
-VERSION=$(node -p "require('./packages/opencontrol/package.json').version")
 
 # Extract changelog notes for the current version
 CHANGELOG_FILE="packages/opencontrol/CHANGELOG.md"


### PR DESCRIPTION
Runs the release scripts on main merges.
It only creates a release if there was a version change.

To version bump, run `bun changeset version` and commit. It will create a changelog from all the changesets. If there are no changesets, it does nothing.