### PR TITLE
feat: enable customization of system prompt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mcp",

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -1,9 +1,15 @@
 import { LanguageModelV1Prompt } from "ai"
 import { createEffect, For, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
-import SYSTEM_PROMPT from "./system.txt?raw"
+import DEFAULT_SYSTEM_PROMPT from "./system.txt?raw"
 import { type App } from "opencontrol"
 import { client } from "./client"
+
+declare global {
+  interface Window {
+    CUSTOM_SYSTEM_PROMPT?: string
+  }
+}
 
 const providerMetadata = {
   anthropic: {
@@ -12,6 +18,8 @@ const providerMetadata = {
     },
   },
 }
+
+const SYSTEM_PROMPT = window.CUSTOM_SYSTEM_PROMPT ?? DEFAULT_SYSTEM_PROMPT
 
 // Define initial system messages once
 const getInitialPrompt = (): LanguageModelV1Prompt => {

--- a/packages/opencontrol/src/index.ts
+++ b/packages/opencontrol/src/index.ts
@@ -14,6 +14,7 @@ export interface OpenControlOptions {
   model?: LanguageModelV1
   app?: Hono
   origin?: string
+  systemPrompt?: string
 }
 
 export type App = ReturnType<typeof create>
@@ -61,7 +62,21 @@ export function create(input: OpenControlOptions) {
 
   return baseApp
     .get("/", async (c) => {
-      return c.html(HTML)
+      if (!input.systemPrompt) {
+        return c.html(HTML)
+      }
+
+      // Validate systemPrompt is a non-empty string
+      if (typeof input.systemPrompt !== "string" || input.systemPrompt.trim().length === 0) {
+        return c.html(HTML)
+      }
+
+      const scriptContent = `window.CUSTOM_SYSTEM_PROMPT=${JSON.stringify(input.systemPrompt)};`
+      const injectedHtml = HTML.replace(
+        "</head>",
+        `<script>${scriptContent}</script></head>`,
+      )
+      return c.html(injectedHtml)
     })
     .post(
       "/generate",

--- a/packages/opencontrol/src/index.ts
+++ b/packages/opencontrol/src/index.ts
@@ -67,7 +67,10 @@ export function create(input: OpenControlOptions) {
       }
 
       // Validate systemPrompt is a non-empty string
-      if (typeof input.systemPrompt !== "string" || input.systemPrompt.trim().length === 0) {
+      if (
+        typeof input.systemPrompt !== "string" ||
+        input.systemPrompt.trim().length === 0
+      ) {
         return c.html(HTML)
       }
 


### PR DESCRIPTION
Enables customization of the system prompt via `OpenControlOptions.systemPrompt`, so we can send system prompts as a parameter to open control, instead of having to commit it to the repo every time.