### PR TITLE
upgrade ai sdk to v6 and migrate to LanguageModelV3

### DIFF
--- a/.changeset/upgrade-ai-sdk-v6.md
+++ b/.changeset/upgrade-ai-sdk-v6.md
@@ -1,0 +1,10 @@
+---
+"opencontrol": patch
+---
+
+Upgrade `ai` to v6 (`6.0.175`) and `zod` to `3.25.76`. Migrate from
+`LanguageModelV1` to `LanguageModelV3` (now imported from
+`@ai-sdk/provider`). Updates the `/generate` request/response shapes
+and tool-call/tool-result content parts to the v3 protocol
+(`input`/`output` instead of `args`/`result`, `providerOptions` instead
+of `providerMetadata`, structured `finishReason`).

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mcp",
@@ -31,7 +32,8 @@
       "name": "opencontrol-frontend",
       "version": "0.0.7",
       "dependencies": {
-        "ai": "4.2.11",
+        "@ai-sdk/provider": "3.0.8",
+        "ai": "6.0.175",
         "hono": "4.7.5",
         "opencontrol": "workspace:*",
         "solid-js": "1.9.5",
@@ -50,12 +52,13 @@
         "opencontrol": "./bin/index.mjs",
       },
       "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
         "@hono/zod-validator": "0.4.3",
         "@modelcontextprotocol/sdk": "1.9.0",
         "@tsconfig/bun": "1.0.7",
-        "ai": "4.2.11",
+        "ai": "6.0.175",
         "hono": "4.7.5",
-        "zod": "3.24.2",
+        "zod": "3.25.76",
         "zod-to-json-schema": "3.24.4",
       },
       "devDependencies": {
@@ -86,20 +89,18 @@
     "protobufjs",
   ],
   "overrides": {
-    "zod": "3.24.2",
+    "zod": "3.25.76",
   },
   "packages": {
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.110", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg=="],
+
     "@ai-sdk/google": ["@ai-sdk/google@1.2.3", "", { "dependencies": { "@ai-sdk/provider": "1.1.0", "@ai-sdk/provider-utils": "2.2.1" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-zsgwko7T+MFIdEfhg4fIXv6O2dnzTLFr6BOpAA21eo/moOBA5szVzOto1jTwIwoBYsF2ixPGNZBoc+k/fQ2AWw=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "1.0.11", "@ai-sdk/provider-utils": "2.1.13" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-COK7LzspgQQh5Yq070xfDdVMvp8WX592rXRaMaYNNqu1xpzahxDcM24aF9xgKYWuYH0UMoOw4UmWGwGxr6ygIg=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@1.1.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.3", "", { "dependencies": { "@ai-sdk/provider": "1.1.0", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-o3fWTzkxzI5Af7U7y794MZkYNEsxbjLam2nxyoUZSScqkacb7vZ3EYHLh21+xCcSSzEC161C7pZAGHtC0hTUMw=="],
-
-    "@ai-sdk/react": ["@ai-sdk/react@1.2.5", "", { "dependencies": { "@ai-sdk/provider-utils": "2.2.3", "@ai-sdk/ui-utils": "1.2.4", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["zod"] }, "sha512-0jOop3S2WkDOdO4X5I+5fTGqZlNX8/h1T1eYokpkR9xh8Vmrxqw8SsovqGvrddTsZykH8uXRsvI+G4FTyy894A=="],
-
-    "@ai-sdk/ui-utils": ["@ai-sdk/ui-utils@1.2.4", "", { "dependencies": { "@ai-sdk/provider": "1.1.0", "@ai-sdk/provider-utils": "2.2.3", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-wLTxEZrKZRyBmlVZv8nGXgLBg5tASlqXwbuhoDu0MhZa467ZFREEnosH/OC/novyEHTQXko2zC606xoVbMrUcA=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
@@ -517,8 +518,6 @@
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
-    "@types/diff-match-patch": ["@types/diff-match-patch@1.0.36", "", {}, "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="],
-
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -557,6 +556,8 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
@@ -571,7 +572,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@4.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.0", "@ai-sdk/provider-utils": "2.2.3", "@ai-sdk/react": "1.2.5", "@ai-sdk/ui-utils": "1.2.4", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-XvYFz+I2MNpkNeso/cEvm2q22cuU7B3EdUxGyhpa94gHbb3HEk73d42+UPJqweSBmoXA52mZ9qvb6jt3P4TITQ=="],
+    "ai": ["ai@6.0.175", "", { "dependencies": { "@ai-sdk/gateway": "3.0.110", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
@@ -766,8 +767,6 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@5.2.0", "", {}, "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="],
-
-    "diff-match-patch": ["diff-match-patch@1.0.5", "", {}, "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -1112,8 +1111,6 @@
     "json-stringify-nice": ["json-stringify-nice@1.1.4", "", {}, "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
@@ -1507,8 +1504,6 @@
 
     "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
 
-    "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
-
     "read-cmd-shim": ["read-cmd-shim@4.0.0", "", {}, "sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q=="],
 
     "read-package-json-fast": ["read-package-json-fast@3.0.2", "", { "dependencies": { "json-parse-even-better-errors": "^3.0.0", "npm-normalize-package-bin": "^3.0.0" } }, "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw=="],
@@ -1723,13 +1718,9 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "swr": ["swr@2.3.3", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A=="],
-
     "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
-
-    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
@@ -1813,8 +1804,6 @@
 
     "url": ["url@0.10.3", "", { "dependencies": { "punycode": "1.3.2", "querystring": "0.2.0" } }, "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ=="],
 
-    "use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
-
     "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -1889,7 +1878,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.1", "", {}, "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="],
 
-    "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.4", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-0uNlcvgabyrni9Ag8Vghj21drk7+7tp7VTwwR7KxxXXc/3pbXz2PHlDgj3cICahgF1kHm4dExBFj7BXrZJXzig=="],
 
@@ -1897,11 +1886,21 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@1.1.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew=="],
+
     "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.1", "", { "dependencies": { "@ai-sdk/provider": "1.1.0", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-BuExLp+NcpwsAVj1F4bgJuQkSqO/+roV9wM7RdIO+NVrcT8RBUTdXzf5arHt5T58VpK7bZyB2V9qigjaPHE+Dg=="],
 
     "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@1.0.11", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-CPyImHGiT3svyfmvPvAFTianZzWFtm0qK82XjwlQIA1C3IQ2iku/PMQXi7aFyrX0TyMh3VTkJPB03tjU2VXVrw=="],
 
     "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.1.13", "", { "dependencies": { "@ai-sdk/provider": "1.0.11", "eventsource-parser": "^3.0.0", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.0.0" }, "optionalPeers": ["zod"] }, "sha512-kLjqsfOdONr6DGcGEntFYM1niXz1H05vyZNf9OAzK+KKKc64izyP4/q/9HX7W4+6g8hm6BnmKxu8vkr6FSOqDg=="],
+
+    "@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "@astrojs/telemetry/ci-info": ["ci-info@4.2.0", "", {}, "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg=="],
 
@@ -1978,6 +1977,8 @@
     "@shikijs/langs/@shikijs/types": ["@shikijs/types@3.2.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA=="],
 
     "@shikijs/themes/@shikijs/types": ["@shikijs/types@3.2.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA=="],
+
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semi": false
   },
   "overrides": {
-    "zod": "3.24.2"
+    "zod": "3.25.76"
   },
   "trustedDependencies": [
     "@rocicorp/zero-sqlite3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,7 +18,8 @@
     "vite-plugin-solid": "2.11.6"
   },
   "dependencies": {
-    "ai": "4.2.11",
+    "@ai-sdk/provider": "3.0.8",
+    "ai": "6.0.175",
     "hono": "4.7.5",
     "opencontrol": "workspace:*",
     "solid-js": "1.9.5"

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -1,11 +1,11 @@
-import { LanguageModelV1Prompt } from "ai"
+import type { LanguageModelV3Prompt } from "@ai-sdk/provider"
 import { createEffect, For, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import SYSTEM_PROMPT from "./system.txt?raw"
 import { type App } from "opencontrol"
 import { client } from "./client"
 
-const providerMetadata = {
+const providerOptions = {
   anthropic: {
     cacheControl: {
       type: "ephemeral",
@@ -14,20 +14,14 @@ const providerMetadata = {
 }
 
 // Define initial system messages once
-const getInitialPrompt = (): LanguageModelV1Prompt => {
+const getInitialPrompt = (): LanguageModelV3Prompt => {
   const currentDate = new Date().toDateString()
 
   return [
     {
       role: "system",
       content: `${SYSTEM_PROMPT}\n\nThe current date is ${currentDate}`,
-      providerMetadata: {
-        anthropic: {
-          cacheControl: {
-            type: "ephemeral",
-          },
-        },
-      },
+      providerOptions,
     },
   ]
 }
@@ -50,7 +44,7 @@ export function App() {
     )
 
   const [store, setStore] = createStore<{
-    prompt: LanguageModelV1Prompt
+    prompt: LanguageModelV3Prompt
     isProcessing: boolean
     rate: boolean
   }>({
@@ -91,9 +85,9 @@ export function App() {
         {
           type: "text",
           text: message,
-          providerMetadata: store.prompt.length === 1 ? providerMetadata : {},
         },
       ],
+      providerOptions: store.prompt.length === 1 ? providerOptions : undefined,
     })
 
     while (true) {
@@ -105,18 +99,12 @@ export function App() {
       const response = await client.generate.$post({
         json: {
           prompt: store.prompt,
-          mode: {
-            type: "regular",
-            tools: (await toolDefs).map((tool: any) => ({
-              type: "function",
-              name: tool.name,
-              description: tool.description,
-              parameters: {
-                ...tool.inputSchema,
-              },
-            })),
-          },
-          inputFormat: "messages",
+          tools: (await toolDefs).map((tool: any) => ({
+            type: "function",
+            name: tool.name,
+            description: tool.description,
+            inputSchema: { ...tool.inputSchema },
+          })),
           temperature: 1,
         },
       })
@@ -140,13 +128,21 @@ export function App() {
 
       const result = await response.json()
 
-      if (result.text) {
+      // V3 result shape: content[] array of typed parts
+      const contentParts: Array<any> = Array.isArray(result.content)
+        ? result.content
+        : []
+
+      // Render text parts
+      const textParts = contentParts.filter((p) => p.type === "text")
+      if (textParts.length > 0) {
+        const combinedText = textParts.map((p) => p.text).join("")
         setStore("prompt", store.prompt.length, {
           role: "assistant",
           content: [
             {
               type: "text",
-              text: result.text,
+              text: combinedText,
             },
           ],
         })
@@ -154,22 +150,31 @@ export function App() {
 
       setStore("rate", false)
 
-      if (result.finishReason === "stop") {
+      // V3 finishReason is { unified, raw }
+      const finishReason = result.finishReason?.unified ?? result.finishReason
+
+      if (finishReason === "stop") {
         setStore("isProcessing", false)
         break
       }
 
-      if (result.finishReason === "tool-calls") {
-        for (const item of result.toolCalls!) {
-          console.log("calling tool", item.toolName, item.args)
+      if (finishReason === "tool-calls") {
+        const toolCalls = contentParts.filter((p) => p.type === "tool-call")
+        for (const item of toolCalls) {
+          // V3 tool-call has `input` as JSON string
+          const args =
+            typeof item.input === "string"
+              ? JSON.parse(item.input)
+              : item.input
+          console.log("calling tool", item.toolName, args)
           setStore("prompt", store.prompt.length, {
             role: "assistant",
             content: [
               {
                 type: "tool-call",
-                toolName: item.toolName,
-                args: JSON.parse(item.args),
                 toolCallId: item.toolCallId,
+                toolName: item.toolName,
+                input: args,
               },
             ],
           })
@@ -182,7 +187,7 @@ export function App() {
                 method: "tools/call",
                 params: {
                   name: item.toolName,
-                  arguments: JSON.parse(item.args),
+                  arguments: args,
                 },
               },
             })
@@ -193,9 +198,12 @@ export function App() {
               content: [
                 {
                   type: "tool-result",
-                  toolName: item.toolName,
                   toolCallId: item.toolCallId,
-                  result: response.result.content,
+                  toolName: item.toolName,
+                  output: {
+                    type: "content",
+                    value: response.result.content,
+                  },
                 },
               ],
             })
@@ -235,7 +243,7 @@ export function App() {
                       <div data-slot="tool-header" onClick={toggleArgs}>
                         <span data-slot="tool-icon">🔧</span>
                         <span data-slot="tool-name">
-                          {item.content[0].toolName}
+                          {(item.content[0] as any).toolName}
                         </span>
                         <span data-slot="tool-expand">
                           {showArgs.visible ? "−" : "+"}
@@ -244,7 +252,11 @@ export function App() {
                       {showArgs.visible && (
                         <div data-slot="tool-args">
                           <pre>
-                            {JSON.stringify(item.content[0].args, null, 2)}
+                            {JSON.stringify(
+                              (item.content[0] as any).input,
+                              null,
+                              2,
+                            )}
                           </pre>
                         </div>
                       )}

--- a/packages/opencontrol/package.json
+++ b/packages/opencontrol/package.json
@@ -21,12 +21,13 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/provider": "3.0.8",
     "@hono/zod-validator": "0.4.3",
     "@modelcontextprotocol/sdk": "1.9.0",
     "@tsconfig/bun": "1.0.7",
-    "ai": "4.2.11",
+    "ai": "6.0.175",
     "hono": "4.7.5",
-    "zod": "3.24.2",
+    "zod": "3.25.76",
     "zod-to-json-schema": "3.24.4"
   },
   "devDependencies": {

--- a/packages/opencontrol/src/index.ts
+++ b/packages/opencontrol/src/index.ts
@@ -4,14 +4,18 @@ import { createMcp } from "./mcp.js"
 import { cors } from "hono/cors"
 import HTML from "opencontrol-frontend/dist/index.html" with { type: "text" }
 import { zValidator } from "@hono/zod-validator"
-import { APICallError, LanguageModelV1, LanguageModelV1CallOptions } from "ai"
+import { APICallError } from "ai"
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+} from "@ai-sdk/provider"
 import { z } from "zod"
 import { HTTPException } from "hono/http-exception"
 import type { Context } from "hono"
 
 export interface OpenControlOptions {
   tools: Tool[]
-  model?: LanguageModelV1
+  model?: LanguageModelV3
   app?: Hono
   origin?: string
 }
@@ -27,7 +31,7 @@ export function create(input: OpenControlOptions) {
     if (!input.model)
       throw new HTTPException(400, { message: "No model configured" })
     // @ts-ignore
-    const body = c.req.valid("json") as LanguageModelV1CallOptions
+    const body = c.req.valid("json") as LanguageModelV3CallOptions
     try {
       const result = await input.model.doGenerate(body)
       return c.json(result)
@@ -66,7 +70,7 @@ export function create(input: OpenControlOptions) {
     .post(
       "/generate",
       // @ts-ignore
-      zValidator("json", z.custom<LanguageModelV1CallOptions>()),
+      zValidator("json", z.custom<LanguageModelV3CallOptions>()),
       generateHandler,
     )
     .post("/mcp", mcpHandler)


### PR DESCRIPTION
## Summary

Upgrades the `ai` SDK from v4 to v6 and migrates the codebase from `LanguageModelV1` to `LanguageModelV3`.

## Package changes

- `ai`: `4.2.11` → `6.0.175`
- `zod`: `3.24.2` → `3.25.76` (root override + opencontrol)
- `@ai-sdk/provider`: `3.0.8` (new direct dependency, source of `LanguageModelV3*` types)

## Code changes

**`packages/opencontrol/src/index.ts`**
- `LanguageModelV1` / `LanguageModelV1CallOptions` → `LanguageModelV3` / `LanguageModelV3CallOptions` (imported from `@ai-sdk/provider`)
- `OpenControlOptions.model` is now `LanguageModelV3`

**`packages/frontend/src/app.tsx`**
- `LanguageModelV1Prompt` → `LanguageModelV3Prompt`
- `providerMetadata` → `providerOptions`, hoisted to message level (v3 location)
- `/generate` request body: drop legacy `mode: { type: "regular", tools }` + `inputFormat: "messages"` envelope; tools now passed directly with `inputSchema` instead of `parameters`
- Tool-call content parts: `args` (JSON string) → `input`
- Tool-result content parts: `result` → `output: { type: "content", value }`
- Response handling: `result.text` → iterate `result.content[]` and join `type: "text"` parts
- `finishReason` is now `{ unified, raw }`; code reads `finishReason?.unified ?? finishReason` for back-compat

## Verification

- `bun install` clean
- `bun run --cwd packages/frontend build` — passes
- `bun run --cwd packages/opencontrol build` — passes (no TS errors, generated `.d.ts` reflects v3 shape)

## Release

Includes a patch changeset (`opencontrol` 0.1.2 → 0.1.3) so the changesets workflow opens a release PR / cuts a release on merge.